### PR TITLE
Fix default shebang in argparse-manpage

### DIFF
--- a/bin/argparse-manpage
+++ b/bin/argparse-manpage
@@ -1,4 +1,4 @@
-#! /bin/python
+#! /usr/bin/python
 
 # Copyright (C) 2017 Red Hat, Inc.
 


### PR DESCRIPTION
This shebang doesn't work on Debian, e.g. (on Fedora you have to
have python-unversioned-command installed).

Related: #17