### PR TITLE
Add 'outfile' argument and use README for long description

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,4 +7,7 @@ New in version 1.2
 
 * LICENSE file included in release tarball.
 
+* 'build_manpage' executable now takes an optional 'OUTFILE' argument. This
+  default to '-' (stdout).
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/build_manpages/build_manpage.py
+++ b/build_manpages/build_manpage.py
@@ -145,12 +145,12 @@ class ManPageWriter(object):
         return ''.join(ret)
 
     def _write_filename(self, filename, what):
+        filename = filename if filename != '-' else '/dev/stdout'
         dirname = os.path.dirname(filename)
         if dirname and not os.path.exists(dirname):
             os.makedirs(dirname)
-        stream = open(filename, 'w')
-        stream.write(what)
-        stream.close()
+        with open(filename, 'w') as stream:
+            stream.write(what)
 
 
     def write(self, filename, seealso=None):

--- a/build_manpages/cli/__init__.py
+++ b/build_manpages/cli/__init__.py
@@ -21,7 +21,6 @@ src_group.add_argument(
     "--module",
     help="search the OBJECT/FUNCTION in MODULE"
 )
-
 src_group.add_argument(
     "--pyfile",
     help="search the OBJECT/FUNCTION in FILE"
@@ -34,7 +33,8 @@ obj_group.add_argument(
 )
 obj_group.add_argument(
     "--object",
-    help="obtain ArgumentParser OBJECT from FUNCTION (to get argparse object) from MODULE or FILE",
+    help="obtain ArgumentParser OBJECT from FUNCTION (to get argparse object) "
+    "from MODULE or FILE",
 )
 
 
@@ -42,6 +42,9 @@ ap.add_argument("--author", action=fake_cmd.getAction())
 ap.add_argument("--author-email", action=fake_cmd.getAction())
 ap.add_argument("--project-name", dest='name', action=fake_cmd.getAction())
 ap.add_argument("--url", action=fake_cmd.getAction())
+ap.add_argument(
+    "outfile", nargs='?', default='-',
+    help="output file; default to stdout")
 
 
 def main():
@@ -61,4 +64,4 @@ def main():
 
     parser = get_parser(import_type, import_from, obj_name, obj_type)
     mw = ManPageWriter(parser, fake_cmd)
-    mw.write_with_manpage('/dev/stdout')
+    mw.write_with_manpage(args.outfile)


### PR DESCRIPTION
At present, I'm having to invoke bash from tox so I can call the script
manually. I'd like to avoid having to do that.