### PR TITLE
Provide argparse-manpage executable via entry_point

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,11 @@ manual pages.
 
 You can also use `argparse-manpage` command on a command-line. Example:
 
-    bin/argparse-manpage --pyfile ./pythonfile --function get_parser --author me --author-email me@domain.com --project-name myproject --url https://pagure.io/myproject > cool-manpage.1
+    argparse-manpage --pyfile ./pythonfile --function get_parser --author me --author-email me@domain.com --project-name myproject --url https://pagure.io/myproject > cool-manpage.1
 
 This reads `./pythonfile` and executes function `get_parser` from it. The function should be programmed to return an `ArgumentParser` instance which is then used together with the other info supplied on the command-line to generate the man page.
 
-See `bin/argparse-manpage --help` for full info.
+See `argparse-manpage --help` for full info.
 
 # License
 

--- a/bin/argparse-manpage
+++ b/bin/argparse-manpage
@@ -1,8 +1,0 @@
-#! /usr/bin/python
-
-# Copyright (C) 2017 Red Hat, Inc.
-
-from build_manpages.cli import main
-
-if __name__ == "__main__":
-    main()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,11 @@ setup(
     maintainer='Pavel Raiskup',
     maintainer_email='praiskup@redhat.com',
     packages=find_packages(),
-    scripts=['bin/argparse-manpage'],
+    entry_points={
+        'console_scripts': [
+            'argparse-manpage=build_manpages.cli:main',
+        ],
+    },
     description='Build manual page from python\'s ArgumentParser object.',
     long_description=get_readme(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR removes the manual `bin/argparse-manpage` entry_point-style script, and replaces it with an `entry_points` entry in `setup.py`. This should make it easier to build cross-platform builds of this package with, e.g, conda-build, and also means you don't have to worry about shebangs etc.