### PR TITLE
Add support for epilog using 'COMMENTS' section

### DIFF
--- a/build_manpages/manpage.py
+++ b/build_manpages/manpage.py
@@ -58,6 +58,10 @@ class Manpage(object):
         for action_group in self.parser._action_groups:
             lines.append(self.mf.format_action_group(action_group, self.parser.prog))
 
+        if self.parser.epilog != None:
+            lines.append('.SH COMMENTS')
+            lines.append(self.format_text(self.parser.epilog))
+
         # Additional Section
         for section in self.parser._manpage:
             lines.append('.SH {}'.format(section['heading'].upper()))

--- a/examples/copr/copr_cli/main.py
+++ b/examples/copr/copr_cli/main.py
@@ -605,7 +605,7 @@ def setup_parser():
     ###                    General options                ###
     #########################################################
 
-    parser = argparse.ArgumentParser(prog="copr")
+    parser = argparse.ArgumentParser(prog="copr", epilog="dummy text")
     # General connection options
 
     parser.add_argument("--debug", dest="debug", action="store_true",

--- a/examples/copr/expected-output.1
+++ b/examples/copr/expected-output.1
@@ -309,7 +309,7 @@ Mark the build as a background job. It will have lesser priority than regular
 builds.
 
 .SH OPTIONS 'copr buildpypi'
-usage: copr buildpypi [-h] [--pythonversions [VERSION ...]]
+usage: copr buildpypi [-h] [--pythonversions [VERSION [VERSION ...]]]
                       [--packageversion PYPIVERSION] --packagename PYPINAME
                       [--memory MEMORY] [--timeout TIMEOUT] [--nowait]
                       [-r CHROOTS] [--background]
@@ -962,6 +962,9 @@ SCM with modulemd file in yaml format
 .TP
 \fB\-\-yaml\fR \fI\,YAML\/\fR
 Path to modulemd file in yaml format
+
+.SH COMMENTS
+dummy text
 
 .SH AUTHORS
 .B example


### PR DESCRIPTION
Implements #5 

Renders epilog as `COMMENTS`.

Output from copr_example:
![image](https://user-images.githubusercontent.com/21097167/101186922-b4f79800-3679-11eb-847f-1d88ce3077da.png)


