### PR TITLE
manpage: Split out options by argument group.

### DIFF
--- a/examples/copr/copr_cli/main.py
+++ b/examples/copr/copr_cli/main.py
@@ -617,7 +617,7 @@ def setup_parser():
     parser.add_argument("--version", action="version",
                         version="%(prog)s version " + version())
 
-    subparsers = parser.add_subparsers(title="actions")
+    subparsers = parser.add_subparsers()
 
     #########################################################
     ###                    Project options                ###

--- a/examples/copr/expected-output.1
+++ b/examples/copr/expected-output.1
@@ -5,7 +5,6 @@ copr
 .B copr
 [-h] [--debug] [--config CONFIG] [--version] {whoami,list,mock-config,create,modify,delete,fork,build,buildpypi,buildgem,buildfedpkg,buildtito,buildmock,status,download-build,cancel,watch-build,delete-build,edit-chroot,get-chroot,add-package-tito,edit-package-tito,add-package-pypi,edit-package-pypi,add-package-mockscm,edit-package-mockscm,add-package-rubygems,edit-package-rubygems,list-packages,list-package-names,get-package,delete-package,reset-package,build-package,build-module} ...
 .SH OPTIONS
-
 .TP
 \fB\-\-debug\fR
 Enable debug output

--- a/examples/raw-description/expected-output.1
+++ b/examples/raw-description/expected-output.1
@@ -16,7 +16,6 @@ As an example of 'dg' usage, to generate _Dockerfile_ for Fedora
       \-\-template  docker.tpl            \\
       \-\-distro    fedora\-21\-x86_64.yaml
 .SH OPTIONS
-
 .TP
 \fB\-\-projectdir\fR PROJECTDIR
 Directory with project (defaults to CWD)

--- a/examples/resalloc/expected/man/resalloc-maint.1
+++ b/examples/resalloc/expected/man/resalloc-maint.1
@@ -5,13 +5,12 @@ resalloc-maint
 .B resalloc-maint
 [-h] [--duh DUH] {resource-list,resource-delete,ticket-list} ...
 .SH OPTIONS
-
 .TP
 \fB\-\-duh\fR \fI\,DUH\/\fR
 huhh
 
-.SS
-\fBSub-commands\fR
+.SH
+ACTIONS
 .TP
 \fBresalloc-maint\fR \fI\,resource-list\/\fR
 List available resources

--- a/examples/resalloc/expected/man/resalloc.1
+++ b/examples/resalloc/expected/man/resalloc.1
@@ -5,15 +5,14 @@ resalloc
 .B resalloc
 [-h] [--connection CONNECTION] [--version] {ticket,ticket-check,ticket-wait,ticket-close} ...
 .SH OPTIONS
-
 .TP
 \fB\-\-connection\fR \fI\,CONNECTION\/\fR
 .TP
 \fB\-\-version\fR
 show program's version number and exit
 
-.SS
-\fBSub-commands\fR
+.SH
+ACTIONS
 .TP
 \fBresalloc\fR \fI\,ticket\/\fR
 Create ticket

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,13 +7,26 @@ sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')]+sys.
 from build_manpages.manpage import Manpage
 
 
-class TestEscapes(unittest.TestCase):
+class Tests(unittest.TestCase):
 
     def test_backslash_escape(self):
         parser = argparse.ArgumentParser('duh')
         parser.add_argument("--jej", help="c:\\something")
         man = Manpage(parser)
         assert 'c:\\\\something' in str(man).split('\n')
+        assert '.SH OPTIONS' in str(man).split('\n')
+
+    def test_argument_groups(self):
+        parser1 = argparse.ArgumentParser('duh')
+        parser = parser1.add_argument_group('g1')
+        parser.add_argument("--jej", help="c:\\something")
+        parser2 = parser1.add_argument_group('g2')
+        parser2.add_argument("--jej2", help="c:\\something")
+        parser2.add_argument("--else", help="c:\\something")
+        man = Manpage(parser1)
+        self.assertIn('.SH G1', str(man).split('\n'))
+        self.assertIn('.SH G2', str(man).split('\n'))
+        self.assertNotIn('.SH OPTIONS', str(man).split('\n'))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi again,

Here I introduce some opinion, that the manpage should separate the options by argument group rather than putting them all under the OPTIONS heading. For programs with lots of options it helps to organise them e.g. like https://wwood.github.io/CoverM/coverm-genome.html

Thoughts?