### PR TITLE
rpm: use 'python setup.py sdist' tarball for CI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,14 +2,10 @@ include argparse-manpage
 include AUTHORS
 include LICENSE
 include NEWS
-recursive-include examples *.py *.txt *.cfg *.md
+recursive-include examples *.py *.cfg *.md expected-output.1 expected/**.1 requirements.txt
 recursive-include tests *.py
 recursive-include unittests *.py
 include examples/argument_groups/bin/test
-include examples/argument_groups/expected/test.1
-include examples/copr/expected-output.1
-include examples/old_format/expected-output.1
-include examples/raw-description/expected-output.1
 include examples/resalloc/expected/man/resalloc-maint.1
 include examples/resalloc/expected/man/resalloc.1
 include examples/copr/fake-deps/HACK
@@ -17,4 +13,3 @@ include examples/copr/fake-deps/copr/README
 include examples/raw-description/bin/dg
 include examples/resalloc/bin/resalloc
 include examples/resalloc/bin/resalloc-maint
-include examples/old_format_file_name/expected-output.1

--- a/rpm/Makefile
+++ b/rpm/Makefile
@@ -11,8 +11,7 @@ all: argparse-manpage.spec argparse-manpage-$(VERSION).tar.gz
 .PHONY: $(TARBALL)
 $(TARBALL):
 	rm -f $(TARBALL)
-	( cd .. && git archive --prefix argparse-manpage-$(VERSION)/ HEAD ) \
-	    | gzip > "$@"
+	cd .. && python3 setup.py sdist && cp "dist/argparse-manpage-$(VERSION).tar.gz" rpm/
 
 argparse-manpage.spec: argparse-manpage.spec.tpl ../setup.py
 	@echo "  GEN $@" ; \


### PR DESCRIPTION
The 'git archive' tarball doesn't provide the needed metadata for
'twine' uploads and without testing the 'sdist' tarball in CI the file
list got often de-synced (complicating the release process later).