### PR TITLE
The in-tree-build flag from pip has been removed.

### DIFF
--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -49,8 +49,15 @@ def _rmtree(directory):
 def run_pip(args):
     environ = os.environ.copy()
     environ['PYTHONPATH'] = ':'.join(sys.path)
-    subprocess.call([sys.executable, '-m', 'pip'] + args + ["--use-feature=in-tree-build", "."],
-                    env=environ)
+    from pip import __version__
+
+    pip_version = tuple([int(x) for x in __version__.split('.')[:2]])
+    if pip_version < (21, 3):
+        subprocess.call(
+            [sys.executable, '-m', 'pip'] + args + ["--use-feature=in-tree-build", "."],
+            env=environ)
+    else:
+        subprocess.call([sys.executable, '-m', 'pip'] + args + ["."], env=environ)
 
 
 def run_setup_py(args):


### PR DESCRIPTION
The in-tree builds are the default behavior for pip >= 21.3 now.

See also: https://github.com/pypa/pip/commit/040cc391baceaad0e8e294e7a3658f08fd12aee2