### PR TITLE
Several new configuration/cmd-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,16 @@ follows a list of options of format `option=value`.  Supported values are:
 - function - the name of function in pyfile to call to get the argparse object
 - format - format of the generated man page: `pretty` (default), `single-commands-section`
 - author - author of the program; can be specified multiple times
-- description - description of the program
-- long_description - verbose description of the program
+- description - description of the program, used in the NAME section, after the
+    leading 'name - ' part, see man (7) man-pages for more info
 - project_name - name of the project the program is part of
+- version - version of the project, visible in manual page footer
 - prog - value that substitutes %prog in ArgumentParser's usage
 - url - link to project download page
-- version - version of the program
+- manual_section - section of the manual, by default 1, see man (7) man-pages
+    for more info about existing sections
+- manual_title - the title of the manual, by default "Generated Python Manual",
+    see man (7) man-pages for more instructions
 
 The values from setup.cfg override values from setup.py's setup().
 

--- a/build_manpages/build_manpage.py
+++ b/build_manpages/build_manpage.py
@@ -51,7 +51,7 @@ class ManPageWriter(object):
         ret.append('.TH %s 1 %s "%s v.%s"\n' % (self._markup(prog),
                                       self._today.strftime('%Y\\-%m\\-%d'), prog, version))
 
-        description = self.values["description"]
+        description = self.values.get("description")
         if description:
             name = self._markup('%s - %s' % (prog, description.splitlines()[0]))
         else:

--- a/build_manpages/cli.py
+++ b/build_manpages/cli.py
@@ -44,9 +44,13 @@ obj_group.add_argument(
 
 ap.add_argument("--project-name", help="Name of the project the documented program is part of.")
 ap.add_argument("--prog", help="Substitutes %%prog in ArgumentParser's usage.")
-ap.add_argument("--version", help="Version of the program.")
-ap.add_argument("--description", metavar="TEXT", help="Description of the program.")
-ap.add_argument("--long-description", metavar="TEXT", help="Extended description of the program.")
+ap.add_argument("--version", help=(
+    "Version of the program, will be visible in the "
+    "manual page footer."))
+ap.add_argument("--description", metavar="TEXT", help=(
+    "description of the program, used in the NAME section, after the "
+    "leading 'name - ' part, see man (7) man-pages for more info"))
+ap.add_argument("--long-description", metavar="TEXT", help=argparse.SUPPRESS)
 ap.add_argument("--author", action="append", dest="authors", metavar="[AUTHOR]",
                 help="Author of the program. Can be specified multiple times.")
 ap.add_argument("--author-email", action="append", dest="authors",
@@ -56,6 +60,12 @@ ap.add_argument("--format", default="pretty", choices=("pretty", "single-command
                 help="Format of the generated man page. Defaults to 'pretty'.")
 ap.add_argument("--output", dest='outfile', default='-',
                 help="Output file. Defaults to stdout.")
+ap.add_argument("--manual-section", help=(
+    "Section of the manual, by default 1.  See man (7) man-pages for more "
+    "info about existing sections."))
+ap.add_argument("--manual-title", help=(
+    "The title of the manual, by default \"Generated Python Manual\". "
+    "See man (7) man-pages for more instructions."))
 
 
 def args_to_manpage_data(args):

--- a/examples/argument_groups/expected/test.1
+++ b/examples/argument_groups/expected/test.1
@@ -1,4 +1,4 @@
-.TH TEST "1" Manual
+.TH TEST "2" "2022\-10\-26" "example 0.1.0" "Test Manual"
 .SH NAME
 test \- templating system/generator for distributions
 .SH SYNOPSIS

--- a/examples/argument_groups/setup.cfg
+++ b/examples/argument_groups/setup.cfg
@@ -1,3 +1,3 @@
 [build_manpages]
 manpages =
-    man/test.1:object=parser:pyfile=bin/test
+    man/test.1:object=parser:pyfile=bin/test:manual_section=2:manual_title=Test Manual

--- a/examples/copr/expected-output.1
+++ b/examples/copr/expected-output.1
@@ -1,4 +1,4 @@
-.TH COPR "1" Manual
+.TH COPR "1" "2022\-10\-26" "example setup\-py\-overriden" "Generated Python Manual"
 .SH NAME
 copr
 .SH SYNOPSIS

--- a/examples/copr/setup.cfg
+++ b/examples/copr/setup.cfg
@@ -1,3 +1,3 @@
 [build_manpages]
 manpages =
-    copr-cli.1:module=copr_cli.main:function=setup_parser
+    copr-cli.1:module=copr_cli.main:function=setup_parser:version=setup-py-overriden

--- a/examples/old_format/expected-output.1
+++ b/examples/old_format/expected-output.1
@@ -1,6 +1,6 @@
 .TH example 1 2017\-09\-24 "example v.0.1.0.dev0"
 .SH NAME
-example \- This script does nothing.
+example
 .SH SYNOPSIS
 .B example
 The usage.

--- a/examples/old_format_file_name/expected-output.1
+++ b/examples/old_format_file_name/expected-output.1
@@ -1,6 +1,6 @@
 .TH example 1 2017\-09\-24 "example v.0.1.0.dev0"
 .SH NAME
-example \- This script does nothing.
+example
 .SH SYNOPSIS
 .B example
 The usage.

--- a/examples/osc/expected-output.1
+++ b/examples/osc/expected-output.1
@@ -1,6 +1,6 @@
-.TH OSC "1" Manual
+.TH OSC "1" "2022\-10\-26" "osc 1.0" "Generated Python Manual"
 .SH NAME
-osc
+osc \- openSUSE commander command\-line
 .SH SYNOPSIS
 .B osc
 [global opts] <command> [--help] [opts] [args] osc --help

--- a/examples/osc/setup.cfg
+++ b/examples/osc/setup.cfg
@@ -1,3 +1,3 @@
 [build_manpages]
 manpages =
-    osc.1:module=osc.main:function=get_parser:format=single-commands-section:prog=osc:author=Contributors to the osc project. See the project's GIT history for the complete list.
+    osc.1:module=osc.main:function=get_parser:format=single-commands-section:description=openSUSE commander command-line:prog=osc:author=Contributors to the osc project. See the project's GIT history for the complete list.

--- a/examples/raw-description/expected-output.1
+++ b/examples/raw-description/expected-output.1
@@ -1,4 +1,4 @@
-.TH DG "1" Manual
+.TH DG "1" "2022\-10\-26" "example 0.1.0" "Generated Python Manual"
 .SH NAME
 dg \- templating system/generator for distributions
 .SH SYNOPSIS

--- a/examples/resalloc/expected/man/resalloc-maint.1
+++ b/examples/resalloc/expected/man/resalloc-maint.1
@@ -1,8 +1,8 @@
-.TH RESALLOC-MAINT "1" Manual
+.TH RESALLOC\-MAINT "1" "2022\-10\-26" "resalloc 0" "Generated Python Manual"
 .SH NAME
-resalloc-maint
+resalloc\-maint
 .SH SYNOPSIS
-.B resalloc-maint
+.B resalloc\-maint
 [-h] [--duh DUH] {resource-list,resource-delete,ticket-list} ...
 
 .SH OPTIONS

--- a/examples/resalloc/expected/man/resalloc.1
+++ b/examples/resalloc/expected/man/resalloc.1
@@ -1,4 +1,4 @@
-.TH RESALLOC "1" Manual
+.TH RESALLOC "1" "2022\-10\-26" "resalloc 0" "Generated Python Manual"
 .SH NAME
 resalloc
 .SH SYNOPSIS


### PR DESCRIPTION
The new 'manual_section'/--manual-section allows us to specify a desired manual page version.

The new 'manual_title'/--manual--title option allows us to specify manual page title.

The 'version'/--version has a better documentation now, and is fixed so it has the effect.

The 'description'/--description now has the needed effect, and better documentation.

The 'long_description' is deprecated, unused and hidden.  It doesn't make sense to mixup project-description with the utility description. Utility description is directly in the Argparse object.

Added test-cases for all the variants.

Fixes: #15
Fixes: #62