### PR TITLE
setup: drop useless py_modules= statement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     version=__version__,
     url='https://github.com/praiskup/argparse-manpage',
     license='Apache 2.0',
-    py_modules = ['build_manpage'],
     author='Gabriele Giammatteo',
     author_email='gabriele.giammatteo@eng.it',
     maintainer='Pavel Raiskup',


### PR DESCRIPTION
This was actually giving us a warning:

    $ python setup.py build_py
    ...
    file build_manpage.py (for module build_manpage) not found