### PR TITLE
Manpage: don't require the data= option

### DIFF
--- a/argparse_manpage/cli.py
+++ b/argparse_manpage/cli.py
@@ -93,5 +93,5 @@ def main():
 
     parser = get_parser(import_type, import_from, obj_name, obj_type, prog=args.prog)
     data = args_to_manpage_data(args)
-    manpage = Manpage(parser, data, args.format)
+    manpage = Manpage(parser, format=args.format, _data=data)
     write_to_filename(str(manpage), args.outfile)

--- a/build_manpages/build_manpages.py
+++ b/build_manpages/build_manpages.py
@@ -93,7 +93,7 @@ class build_manpages(Command):
             parser = get_parser(data['import_type'], data['import_from'], data['objname'], data['objtype'], data.get('prog', None))
             format = data.get('format', 'pretty')
             if format in ('pretty', 'single-commands-section'):
-                manpage = Manpage(parser, data, format)
+                manpage = Manpage(parser, format=format, _data=data)
                 write_to_filename(str(manpage), page)
             elif format == 'old':
                 # TODO: drop the "old" format support, and stop depending on ManPageWriter

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -12,17 +12,10 @@ from build_manpages.manpage import Manpage
 
 
 class Tests(unittest.TestCase):
-
-    _fake_data = {
-        "project_name": "argparse-manpage-testsuite",
-        "authors": None,
-        "url": None,
-    }
-
     def test_backslash_escape(self):
         parser = argparse.ArgumentParser('duh')
         parser.add_argument("--jej", help="c:\\something")
-        man = Manpage(parser, self._fake_data)
+        man = Manpage(parser)
         assert 'c:\\\\something' in str(man).split('\n')
         assert '.SH OPTIONS' in str(man).split('\n')
 
@@ -33,7 +26,7 @@ class Tests(unittest.TestCase):
         parser2 = parser1.add_argument_group('g2')
         parser2.add_argument("--jej2", help="c:\\something")
         parser2.add_argument("--else", help="c:\\something")
-        man = Manpage(parser1, self._fake_data)
+        man = Manpage(parser1)
         self.assertIn('.SH G1', str(man).split('\n'))
         self.assertIn('.SH G2', str(man).split('\n'))
         self.assertNotIn('.SH OPTIONS', str(man).split('\n'))
@@ -50,7 +43,7 @@ class Tests(unittest.TestCase):
                  "provided "
         )
 
-        manpage_lines = str(Manpage(parser, self._fake_data)).split("\n")
+        manpage_lines = str(Manpage(parser)).split("\n")
         exp_line = '\\fBaliases_test\\fR \\fI\\,list\\/\\fR'
         not_exp_line = '\\fBaliases_test\\fR \\fI\\,ls\\/\\fR'
         assert exp_line in manpage_lines


### PR DESCRIPTION
The definition of the data= is blurry, and it's better to not use it from the outside, it could change.  Try to hide it from users (make it optional and private), and actually revert a change that the old Manpage() API.

Relates: #7