### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -1,6 +1,8 @@
 from argparse import SUPPRESS, HelpFormatter, _SubParsersAction, _HelpAction
 from collections import OrderedDict
 import datetime
+import os
+import time
 
 
 DEFAULT_GROUP_NAMES = {
@@ -146,7 +148,10 @@ class Manpage(object):
 
         self.date = self._data.get("date")
         if not self.date:
-            self.date = datetime.datetime.now().strftime('%Y-%m-%d')
+            builddate = datetime.datetime.utcfromtimestamp(
+                int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+            )
+            self.date = builddate.strftime('%Y-%m-%d')
 
         self.source = self._data.get("project_name")
         if not self.source:

--- a/build_manpages/build_manpage.py
+++ b/build_manpages/build_manpage.py
@@ -5,6 +5,8 @@
 import datetime
 import optparse
 import argparse
+import os
+import time
 import warnings
 
 from distutils.core import Command
@@ -34,7 +36,9 @@ class ManPageWriter(object):
     def __init__(self, parser, values):
         self._parser = parser
         self.values = values
-        self._today = datetime.date.today()
+        self._today = datetime.datetime.utcfromtimestamp(
+            int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+        )
 
         if isinstance(parser, argparse.ArgumentParser):
             self._type = 'argparse'

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -8,6 +8,7 @@ import shutil
 import sys
 import subprocess
 import tempfile
+import time
 
 SIMPLE_FILE_CONTENTS = """
 import argparse
@@ -54,7 +55,9 @@ Mr. Foo <mfoo@example.com> and friends
 .fi
 """
 
-DATE = datetime.datetime.now().strftime("%Y\\-%m\\-%d")
+DATE = datetime.datetime.utcfromtimestamp(
+           int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+       ).strftime("%Y\\-%m\\-%d")
 
 class TestsArgparseManpageScript:
     def setup_method(self, _):


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This patch was done while working on reproducible builds for openSUSE.