### PR TITLE
Add --include command-line flag

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,4 @@ include examples/copr/fake-deps/copr/README
 include examples/raw-description/bin/dg
 include examples/resalloc/bin/resalloc
 include examples/resalloc/bin/resalloc-maint
+include tests/extra.man

--- a/README.md
+++ b/README.md
@@ -114,14 +114,43 @@ follows a list of options of format `option=value`.  Supported values are:
     for more info about existing sections
 - manual_title - the title of the manual, by default "Generated Python Manual",
     see man (7) man-pages for more instructions
+- include - a file of extra material to include; see below for the format
 
 The values from setup.cfg override values from setup.py's setup().
-
 
 Then run `setup.py build_manpages` to build a manpages for your project.  Also,
 if you used `get_build_py` helper, `setup.py build` then transitively builds the
 manual pages.
 
+## Include file format
+
+The include file format is based on GNU `help2man`'s `--include` format.
+
+The format is simple:
+
+```
+[section]
+text
+
+/pattern/
+text
+```
+
+Blocks of verbatim *roff text are inserted into the output either at
+the start of the given `section` (case insensitive), or after a
+paragraph matching `pattern`, a Python regular expression.
+
+Lines before the first section are silently ignored and may be used for
+comments and the like.
+
+Other sections are prepended to the automatically produced output for the
+standard sections given above, or included near the bottom of the man page,
+before the `AUTHOR` section, in the order they occur in the include file.
+
+Placement of the text within the section may be explicitly requested by
+using the syntax `[<section]`, `[=section]` or `[>section]` to place the
+additional text before, in place of, or after the default output
+respectively.
 
 ## Installation
 

--- a/argparse_manpage/cli.py
+++ b/argparse_manpage/cli.py
@@ -66,6 +66,8 @@ ap.add_argument("--manual-section", help=(
 ap.add_argument("--manual-title", help=(
     "The title of the manual, by default \"Generated Python Manual\". "
     "See man (7) man-pages for more instructions."))
+ap.add_argument("--include", metavar="FILE", help=(
+    "File that contains extra material for the man page."))
 
 
 def args_to_manpage_data(args):

--- a/examples/argument_groups/expected/test.1
+++ b/examples/argument_groups/expected/test.1
@@ -1,4 +1,4 @@
-.TH TEST "2" "2022\-10\-26" "example 0.1.0" "Test Manual"
+.TH TEST "2" "2023\-04\-09" "example 0.1.0" "Test Manual"
 .SH NAME
 test \- templating system/generator for distributions
 .SH SYNOPSIS
@@ -69,7 +69,7 @@ usage: test g2arg subparserA sub\-subparserA [\-h] [\-\-doh DOH]
 .TP
 \fB\-\-doh\fR \fI\,DOH\/\fR
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jd@example.com>
 .fi

--- a/examples/copr/expected-output.1
+++ b/examples/copr/expected-output.1
@@ -1,4 +1,4 @@
-.TH COPR "1" "2022\-10\-26" "example setup\-py\-overriden" "Generated Python Manual"
+.TH COPR "1" "2023\-04\-09" "example setup\-py\-overriden" "Generated Python Manual"
 .SH NAME
 copr
 .SH SYNOPSIS
@@ -998,7 +998,7 @@ Path to modulemd file in yaml format
 .SH COMMENTS
 dummy text
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jd@example.com>
 .fi

--- a/examples/old_format/expected-output.1
+++ b/examples/old_format/expected-output.1
@@ -16,7 +16,7 @@ write report to FILE
 .TP
 .B \-q, \-\-quiet
 don't print status messages to stdout
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jd@example.com>
 .fi

--- a/examples/old_format_file_name/expected-output.1
+++ b/examples/old_format_file_name/expected-output.1
@@ -16,7 +16,7 @@ write report to FILE
 .TP
 .B \-q, \-\-quiet
 don't print status messages to stdout
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jd@example.com>
 .fi

--- a/examples/osc/expected-output.1
+++ b/examples/osc/expected-output.1
@@ -1,4 +1,4 @@
-.TH OSC "1" "2022\-10\-26" "osc 1.0" "Generated Python Manual"
+.TH OSC "1" "2023\-04\-09" "osc 1.0" "Generated Python Manual"
 .SH NAME
 osc \- openSUSE commander command\-line
 .SH SYNOPSIS
@@ -91,7 +91,7 @@ help opt\-baz2
 .RE
 
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 Contributors to the osc project. See the project's GIT history for the complete list.
 .fi

--- a/examples/raw-description/expected-output.1
+++ b/examples/raw-description/expected-output.1
@@ -1,4 +1,4 @@
-.TH DG "1" "2022\-10\-26" "example 0.1.0" "Generated Python Manual"
+.TH DG "1" "2023\-04\-09" "example 0.1.0" "Generated Python Manual"
 .SH NAME
 dg \- templating system/generator for distributions
 .SH SYNOPSIS
@@ -65,7 +65,7 @@ Use TEMPLATE file, e.g. docker.tpl or a template string, e.g. "{{ config.docker.
 \fB\-\-multispec\-combinations\fR
 Print available multispec combinations
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jd@example.com>
 .fi

--- a/examples/resalloc/expected/man/resalloc-maint.1
+++ b/examples/resalloc/expected/man/resalloc-maint.1
@@ -1,4 +1,4 @@
-.TH RESALLOC\-MAINT "1" "2022\-10\-26" "resalloc 0" "Generated Python Manual"
+.TH RESALLOC\-MAINT "1" "2023\-04\-09" "resalloc 0" "Generated Python Manual"
 .SH NAME
 resalloc\-maint
 .SH SYNOPSIS
@@ -40,7 +40,7 @@ The resource ID
 .SH COMMAND \fI\,'resalloc\-maint ticket\-list'\/\fR
 usage: resalloc\-maint ticket\-list [\-h]
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 Pavel Raiskup <praiskup@redhat.com>
 .fi

--- a/examples/resalloc/expected/man/resalloc.1
+++ b/examples/resalloc/expected/man/resalloc.1
@@ -1,4 +1,4 @@
-.TH RESALLOC "1" "2022\-10\-26" "resalloc 0" "Generated Python Manual"
+.TH RESALLOC "1" "2023\-04\-09" "resalloc 0" "Generated Python Manual"
 .SH NAME
 resalloc
 .SH SYNOPSIS
@@ -57,7 +57,7 @@ usage: resalloc ticket\-close [\-h] ticket
 \fBticket\fR
 ID of ticket to be closed
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 Pavel Raiskup <praiskup@redhat.com>
 .fi

--- a/tests/extra.man
+++ b/tests/extra.man
@@ -1,0 +1,5 @@
+[EXTRA SECTION]
+This is an extra section.
+
+/John Doe/
+Developer extraordinaire.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -45,10 +45,13 @@ FULL_OUTPUT = """\
 
 .TP
 \\fBtest\\fR
+.SH EXTRA SECTION
+This is an extra section.
 
-.SH AUTHORS
+.SH AUTHOR
 .nf
 John Doe <jdoe@example.com>
+Developer extraordinaire.
 .fi
 .nf
 Mr. Foo <mfoo@example.com> and friends
@@ -134,6 +137,7 @@ class TestsArgparseManpageScript:
             "--project-name", "Proj-On-Cmdline",
             "--description", "some description",
             "--long-description", "Some long description.",  # unused
+            "--include", "tests/extra.man",
         ]
         output = subprocess.check_output(cmd).decode("utf-8")
         name="progname"


### PR DESCRIPTION
I have tried to mimic as best I can the behaviour of help2man, without
changing the way that argparse-manpage works already.

The main effect of this is that the treatment of certain sections that are
individually rendered by argparse-manpage is slightly different from
help2man.

I have also renamed the non-standard “AUTHORS” section to the standard
“AUTHOR”.

I have not yet tried to document or add tests for the new functionality, in
case it’s desired to change it before merging.