### PR TITLE
Allow argparse-manpages to be configured with pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ setup(
 )
 ```
 
-And in the `setup.cfg` configure the manual pages you want to automatically
+And in `setup.cfg` configure the manual pages you want to automatically
 generate and install:
 
 ```
@@ -93,6 +93,17 @@ manpages =
     man/foo.1:object=parser:pyfile=bin/foo.py
     man/bar.1:function=get_parser:pyfile=bin/bar
     man/baz.1:function=get_parser:pyfile=bin/bar:prog=baz
+```
+
+Or in `pyproject.toml` (requires setuptools >= 62.2.0):
+
+```toml
+[build_manpages]
+manpages = [
+    "man/foo.1:object=parser:pyfile=bin/foo.py",
+    "man/bar.1:function=get_parser:pyfile=bin/bar",
+    "man/baz.1:function=get_parser:pyfile=bin/bar:prog=baz",
+]
 ```
 
 The format of those lines is a colon separated list of arguments/options.  The

--- a/argparse_manpage/compat.py
+++ b/argparse_manpage/compat.py
@@ -7,9 +7,9 @@ import sys
 # Drop once Python 2.7 is dropped
 # pylint: disable=unused-import
 try:
-    from configparser import ConfigParser
+    from configparser import ConfigParser, NoSectionError
 except ImportError:
-    from ConfigParser import SafeConfigParser as ConfigParser  # type: ignore
+    from ConfigParser import SafeConfigParser as ConfigParser, NoSectionError  # type: ignore
 
 if sys.version_info < (3, 0):
     import imp  # pylint: disable=deprecated-module

--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -71,10 +71,15 @@ def get_manpage_data_from_distribution(distribution, data):
     """
     # authors
     if not "authors" in data:
-        author = distribution.get_author()
-        if distribution.get_author_email():
-            author += " <{}>".format(distribution.get_author_email())
-        data["authors"] = [author]
+        author = None
+        if distribution.get_author():
+            author = distribution.get_author()
+            if distribution.get_author_email():
+                author += " <{}>".format(distribution.get_author_email())
+        elif distribution.get_author_email():
+            author = distribution.get_author_email()
+        if author:
+            data["authors"] = [author]
 
     attrs = list(MANPAGE_DATA_ATTRS)
     attrs.remove("authors")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = [
+    "setuptools",
+    "toml;python_version<'3.11'",
+]
+
+[tool.build_manpages]
+manpages = [
+    "some-file.1:pyfile=some-file:function=get_parser",
+]

--- a/rpm/argparse-manpage.spec.tpl
+++ b/rpm/argparse-manpage.spec.tpl
@@ -38,6 +38,7 @@ Source0:        https://github.com/praiskup/%{name}/archive/v%{version}/%{name}-
 
 %if %{with python2}
 BuildRequires: python2-setuptools python2-devel
+BuildRequires: python2-toml
 %if %{with check}
 %if 0%{?rhel} && 0%{?rhel} == 7
 BuildRequires: pytest
@@ -49,6 +50,7 @@ BuildRequires: python2-pytest
 
 %if %{with python3}
 BuildRequires: python3-setuptools python3-devel
+BuildRequires: python3-toml
 %if %{with check}
 BuildRequires: python3-pytest
 %endif

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,11 @@ def get_readme():
     with open(os.path.join(ROOT_DIR, 'README.md')) as fh:
         return ''.join(fh.readlines())
 
+if sys.version_info >= (3,):
+    install_requires = ['toml;python_version<"3.11"']
+else:
+    install_requires = ['toml']
+
 setup(
     name='argparse-manpage',
     version=__version__,
@@ -44,6 +49,7 @@ setup(
         'build_py': get_build_py_cmd(),
         'install': get_install_cmd(),
     },
+    install_requires=install_requires,
     extras_require={
         'setuptools': ["setuptools"]
     },

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
 pytest
 setuptools
+toml

--- a/tests/argparse_testlib.py
+++ b/tests/argparse_testlib.py
@@ -2,8 +2,10 @@
 unit-tests helpers
 """
 
+import os
 from platform import python_version
 from pkg_resources import parse_version
+from contextlib import contextmanager
 
 import pytest
 
@@ -22,3 +24,12 @@ def skip_on_python_older_than(minimal_version, message, condition=None):
             python_version(),
         )
         raise pytest.skip("{0} ({1})".format(message, generic_msg))
+
+@contextmanager
+def pushd(path):
+    old_dir = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old_dir)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -58,12 +58,6 @@ def run_setup_py(args):
         return subprocess.call([sys.executable, 'setup.py'] + args,
                                env=environ)
 
-def skip_if_older_python(min_version):
-    def _get_int(version):
-        int_v = [int(sv) for sv in version.split(".")]
-
-
-
 
 def run_one_installer(installer, args):
     """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -64,8 +64,8 @@ def run_setup_py(args):
     environ = os.environ.copy()
     environ['PYTHONPATH'] = ':'.join(sys.path)
     with change_argv(['setup.py'] + args):
-        subprocess.call([sys.executable, 'setup.py'] + args,
-                        env=environ)
+        return subprocess.call([sys.executable, 'setup.py'] + args,
+                               env=environ)
 
 def skip_if_older_python(min_version):
     def _get_int(version):
@@ -112,7 +112,7 @@ def file_cmp(file1, file2, filter_string=None):
                 assert left == right
 
 
-class TestAllExapmles:
+class TestAllExamples:
     def test_old_example(self):
         with pushd('examples/old_format'):
             try:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,22 +12,13 @@ import pytest
 
 sys.path = [os.path.join(os.path.dirname(os.path.realpath(__file__)),'..')]+sys.path
 
-from argparse_testlib import skip_on_python_older_than
+from argparse_testlib import skip_on_python_older_than, pushd
 
 
 def _mandir(prefix, num=1):
     data = sysconfig.get_path('data', vars={'base': prefix})
     return os.path.join(data, 'share/man/man' + str(num))
 
-
-@contextmanager
-def pushd(path):
-    old_dir = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(old_dir)
 
 @contextmanager
 def change_argv(argv):

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -15,6 +15,7 @@ from distutils.version import StrictVersion
 import setuptools
 
 from test_examples import run_setup_py
+from argparse_testlib import pushd
 
 SIMPLE_FILE_CONTENTS = """\
 import argparse
@@ -179,8 +180,7 @@ class TestsArgparseManpageScript:
         Test that we can read information from pyproject.toml.
         """
         current_dir = os.getcwd()
-        try:
-            os.chdir(self.workdir)
+        with pushd(self.workdir):
             with open("pyproject.toml", "w+") as script_fd:
                 script_fd.write(PYPROJECT_TOML_FILE_CONTENTS.format(gitdir=current_dir))
             with open("setup.py", "w+") as script_fd:
@@ -200,6 +200,3 @@ class TestsArgparseManpageScript:
                                                           NAME=name.upper(), DATE=DATE)
             else:
                 warnings.warn("setuptools >= 62.2.0 required to generate man pages with pyprojects.toml")
-
-        finally:
-            os.chdir(current_dir)


### PR DESCRIPTION
This PR adds support for manpage specifications being supplied in the
tool.build_manpages section of pyproject.toml.

Also, it fixes author parsing to work with the information parsed from
pyproject.toml by setuptools, where only author_email is set, not
author (issue #77).