### PR TITLE
Fix the pyproject.toml manpages example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ manpages =
 Or in `pyproject.toml` (requires setuptools >= 62.2.0):
 
 ```toml
-[build_manpages]
+[tool.build_manpages]
 manpages = [
     "man/foo.1:object=parser:pyfile=bin/foo.py",
     "man/bar.1:function=get_parser:pyfile=bin/bar",


### PR DESCRIPTION
This PR fixes this error (that you get when you read the docs and implement the pyproject.toml example):
```console
running build_manpages
error: 'manpages' option is required
```