### PR TITLE
Fix compatibility with newer setuptools

### DIFF
--- a/examples/old_format_file_name/setup.cfg
+++ b/examples/old_format_file_name/setup.cfg
@@ -1,4 +1,4 @@
 [build_manpage]
 output=example.1
 parser=IGNORED:get_parser
-parser-file=example.py
+parser_file=example.py


### PR DESCRIPTION
New setuptools expects all options to use lower_snake_case.