### PR TITLE
Fix deprecation warnings for datetime and setuptools

### DIFF
--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -173,8 +173,9 @@ class Manpage(object):
 
         self.date = self._data.get("date")
         if not self.date:
-            builddate = datetime.datetime.utcfromtimestamp(
-                int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+            builddate = datetime.datetime.fromtimestamp(
+                int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+                datetime.timezone.utc
             )
             self.date = builddate.strftime('%Y-%m-%d')
 

--- a/build_manpages/build_manpage.py
+++ b/build_manpages/build_manpage.py
@@ -36,8 +36,9 @@ class ManPageWriter(object):
     def __init__(self, parser, values):
         self._parser = parser
         self.values = values
-        self._today = datetime.datetime.utcfromtimestamp(
-            int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+        self._today = datetime.datetime.fromtimestamp(
+            int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+            datetime.timezone.utc
         )
 
         if isinstance(parser, argparse.ArgumentParser):

--- a/examples/copr/copr_cli/main.py
+++ b/examples/copr/copr_cli/main.py
@@ -34,8 +34,6 @@ import copr.exceptions as copr_exceptions
 from .util import ProgressBar
 from .build_config import MockProfile
 
-import pkg_resources
-
 ON_OFF_MAP = {
     'on': True,
     'off': False,
@@ -593,7 +591,13 @@ def version():
         # doesn't matter as the version in the manual page is read directly from
         # setuptools.
         return 'fake'
-    return pkg_resources.require('copr-cli')[0].version
+    try:
+        from importlib.metadata import version
+        return version('copr-cli')
+    except ImportError:
+        # importlib.metadata does not exist in Python <3.8.
+        import pkg_resources
+        return pkg_resources.require('copr-cli')[0].version
 
 
 def setup_parser():

--- a/tests/argparse_testlib.py
+++ b/tests/argparse_testlib.py
@@ -4,7 +4,7 @@ unit-tests helpers
 
 import os
 from platform import python_version
-from pkg_resources import parse_version
+from packaging import version
 from contextlib import contextmanager
 
 import pytest
@@ -18,7 +18,7 @@ def skip_on_python_older_than(minimal_version, message, condition=None):
     if condition is not None and not condition:
         return
 
-    if parse_version(python_version()) < parse_version(minimal_version):
+    if version.parse(python_version()) < version.parse(minimal_version):
         generic_msg = "Python {0} required, have {1}".format(
             minimal_version,
             python_version(),

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -89,8 +89,9 @@ manpages = [
 ]
 """
 
-DATE = datetime.datetime.utcfromtimestamp(
-           int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+DATE = datetime.datetime.fromtimestamp(
+           int(os.environ.get('SOURCE_DATE_EPOCH', time.time())),
+           datetime.timezone.utc
        ).strftime("%Y\\-%m\\-%d")
 
 class TestsArgparseManpageScript:


### PR DESCRIPTION
Apparently pkg_resources could be removed on 2025-11-30.
https://setuptools.pypa.io/en/latest/pkg_resources.html

- datetime.datetime.utcfromtimestamp → datetime.datetime.fromtimestamp
- pkg_resources.parse_version → packaging.version.parse
- pkg_resources.require → importlib.metadata.version

```
tests/argparse_testlib.py:7
  /argparse-manpage/tests/argparse_testlib.py:7: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
    from pkg_resources import parse_version

tests/test_script.py:92
  /argparse-manpage/tests/test_script.py:92: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    DATE = datetime.datetime.utcfromtimestamp(

tests/test_basic.py::Tests::test_aliases
tests/test_basic.py::Tests::test_argument_groups
tests/test_basic.py::Tests::test_backslash_escape
  /argparse-manpage/tests/../argparse_manpage/manpage.py:176: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
    builddate = datetime.datetime.utcfromtimestamp(
```