### PR TITLE
fixed action.help is None bug within subcommand

### DIFF
--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -480,7 +480,7 @@ class _ManpageFormatter(HelpFormatter):
                 continue
             lines.append('.TP')
             lines.append(bold(prog) + ' ' + underline(action.dest))
-            if hasattr(action, 'help'):
+            if hasattr(action, 'help') and action.help:
                 lines.append(self.format_text(action.help))
 
         return '\n'.join(lines)


### PR DESCRIPTION
there was a bug, that made argparse-manpage fail with an exception when a subcommand had an empty `help` text (`action.help is None`). Fixed it.