### PR TITLE
Fix AttributeError: _ManpageFormatter._cached_theme on Python 3.15

### DIFF
--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -362,7 +362,7 @@ def quoted(text):
 
 class _ManpageFormatter(HelpFormatter):
     def __init__(self, prog, old_formatter, format):
-        super().__init__(prog)
+        super(_ManpageFormatter, self).__init__(prog)
         self._prog = prog
         self.of = old_formatter
         assert format in ("pretty", "single-commands-section")

--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -362,7 +362,7 @@ def quoted(text):
 
 class _ManpageFormatter(HelpFormatter):
     def __init__(self, prog, old_formatter, format):
-        super(HelpFormatter, self).__init__()
+        super().__init__(prog)
         self._prog = prog
         self.of = old_formatter
         assert format in ("pretty", "single-commands-section")


### PR DESCRIPTION
Changed super(HelpFormatter, self).__init__() to super(_ManpageFormatter, self).__init__(prog) in _ManpageFormatter.__init__ in manpage.py and was able to successfully build with python 3.15. Solves issue #129 