### PR TITLE
fix: remove escape sequencies from generated man pages

### DIFF
--- a/argparse_manpage/manpage.py
+++ b/argparse_manpage/manpage.py
@@ -153,6 +153,7 @@ class Manpage(object):
         """
         self.prog = parser.prog
         self.parser = parser
+        self.parser.color = False
         self.format = format
         self._data = _data or {}
         self._match_texts = []
@@ -427,6 +428,7 @@ class _ManpageFormatter(HelpFormatter):
                     lines.append(help)
                     lines.append("")
 
+            parser.color = False
             lines.append(self.format_text(parser.format_usage()))
 
         if parser.description or extra_description:

--- a/build_manpages/build_manpage.py
+++ b/build_manpages/build_manpage.py
@@ -39,6 +39,7 @@ class ManPageWriter(object):
 
         if isinstance(parser, argparse.ArgumentParser):
             self._type = 'argparse'
+            self._parser.color = False
             if parser.formatter_class == argparse.HelpFormatter:
                 # Hack for issue #36, to have reproducible manual page content
                 # regardless the terminal window size.  Long term we should avoid

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,6 +51,10 @@ class Tests(unittest.TestCase):
         assert 1 == sum([1 if "COMMAND" in line else 0 for line in manpage_lines])
 
     def test_no_color_escapes(self):
+        """
+        Pyhon 3.14+ adds ANSI escape sequencies by default which should not be
+        presented in generated man pages
+        """
         os.environ['FORCE_COLOR'] = '1'
         parser = argparse.ArgumentParser("color_test")
         parser.add_argument("--option", help="something")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -50,6 +50,16 @@ class Tests(unittest.TestCase):
         assert not_exp_line not in manpage_lines
         assert 1 == sum([1 if "COMMAND" in line else 0 for line in manpage_lines])
 
+    def test_no_color_escapes(self):
+        os.environ['FORCE_COLOR'] = '1'
+        parser = argparse.ArgumentParser("color_test")
+        parser.add_argument("--option", help="something")
+        subparsers = parser.add_subparsers(title="actions")
+        subparser = subparsers.add_parser("subparser", help="something else")
+        subparser.add_argument("--actually", help="something")
+        man = Manpage(parser)
+        self.assertNotIn('\x1b', str(man))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
starting since python 3.14 argparse adds colors to output by default, but man doesn't parse escape sequencies correctly, so this commit disables colors completely